### PR TITLE
Change the Scope to use a single namespace for all symbol types

### DIFF
--- a/Nova.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/Nova.Tests/CodeAnalysis/EvaluationTests.cs
@@ -96,7 +96,7 @@ namespace Nova.Tests.CodeAnalysis
             ";
 
             var diagnostics = @"
-                Variable 'x' is already declared.
+                'x' is already declared.
             ";
 
             AssertDiagnostics(text, diagnostics);
@@ -280,6 +280,23 @@ namespace Nova.Tests.CodeAnalysis
 
             var diagnostics = @"
                 Cannot convert type 'bool' to 'int'.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void EvaluatorVariablesCanShadowFunctions()
+        {
+            var text = @"
+                {
+                    let print = ""test""
+                    [print](print)
+                }
+            ";
+
+            var diagnostics = @"
+                'print' is not a function.
             ";
 
             AssertDiagnostics(text, diagnostics);

--- a/NovaLib/CodeAnalysis/Binding/Binder.cs
+++ b/NovaLib/CodeAnalysis/Binding/Binder.cs
@@ -346,7 +346,7 @@ namespace Nova.CodeAnalysis.Binding
             VariableSymbol variable = new VariableSymbol(name, isReadOnly, type);
 
             if (declare && !scope.TryDeclareVariable(variable))
-                diagnostics.ReportVariableAlreadyDeclared(identifier.Span, name);
+                diagnostics.ReportSymbolAlreadyDeclared(identifier.Span, name);
 
             return variable;
         }

--- a/NovaLib/CodeAnalysis/DiagnosticBag.cs
+++ b/NovaLib/CodeAnalysis/DiagnosticBag.cs
@@ -75,9 +75,9 @@ namespace Nova.CodeAnalysis
             Report(span, message);
         }
 
-        public void ReportVariableAlreadyDeclared(TextSpan span, string name)
+        public void ReportSymbolAlreadyDeclared(TextSpan span, string name)
         {
-            string message = $"Variable '{name}' is already declared.";
+            string message = $"'{name}' is already declared.";
             Report(span, message);
         }
 
@@ -89,7 +89,7 @@ namespace Nova.CodeAnalysis
 
         public void ReportUndefinedFunction(TextSpan span, string name)
         {
-            string message = $"Function '{name}' doesn't exist.";
+            string message = $"'{name}' is not a function.";
             Report(span, message);
         }
 


### PR DESCRIPTION
You can still shadow a symbol defined in an outer scope, even if it's of a different type, as shadowing was an intended feature.

Before:
<p align="center">
  <img src="https://user-images.githubusercontent.com/7913492/57571401-01cbac00-740e-11e9-90ab-f47cb91b436f.png">
</p>

After:
<p align="center">
  <img src="https://user-images.githubusercontent.com/7913492/57571411-1445e580-740e-11e9-8bb6-d15b9f3861b8.png">
</p>
