### PR TITLE
Sort diagnostics by span

### DIFF
--- a/NovaLib/CodeAnalysis/Text/TextSpanComparer.cs
+++ b/NovaLib/CodeAnalysis/Text/TextSpanComparer.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Nova.CodeAnalysis.Text
+{
+    public class TextSpanComparer : IComparer<TextSpan>
+    {
+        public int Compare(TextSpan x, TextSpan y)
+        {
+            int textCompared = x.Start - y.Start;
+            if (textCompared == 0)
+                textCompared = x.Length - y.Length;
+
+            return textCompared;
+        }
+    }
+}

--- a/nova/NovaRepl.cs
+++ b/nova/NovaRepl.cs
@@ -121,7 +121,7 @@ namespace Nova
             }
             else
             {
-                foreach (Diagnostic diagnostic in diagnostics)
+                foreach (Diagnostic diagnostic in diagnostics.OrderBy(d => d.Span, new TextSpanComparer()))
                 {
                     SourceText treeText = syntaxTree.Text;
                     int lineIndex = treeText.GetLineIndex(diagnostic.Span.Start);


### PR DESCRIPTION
It makes more sense to show messages in the reverse order. This pull request orders diagnostic messages by the span property.

e.g. for the input "x = 10 * y" the following diagnostics are displayed:

(1, 10): Variable 'y' doesn't exist.
x = 10 * y

(1, 1): Variable 'x' doesn't exist.
x = 10 * y