### PR TITLE
Prevent infinite loops when parsing functions

### DIFF
--- a/Nova.Tests/CodeAnalysis/EvaluationTests.cs
+++ b/Nova.Tests/CodeAnalysis/EvaluationTests.cs
@@ -121,6 +121,43 @@ namespace Nova.Tests.CodeAnalysis
         }
 
         [Fact]
+        public void EvaluatorInvokeFunctionArgumentsNoInfiniteLoop()
+        {
+            var text = @"
+                print(""Hi""[[=]][)]
+            ";
+
+            var diagnostics = @"
+                Unexpected token <EqualsToken>, expected <CloseParenthesisToken>.
+                Unexpected token <EqualsToken>, expected <IdentifierToken>.
+                Unexpected token <CloseParenthesisToken>, expected <IdentifierToken>.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
+        public void EvaluatorFunctionParametersNoInfiniteLoop()
+        {
+            var text = @"
+                function hi(name: string[[[=]]][)]
+                {
+                    print(""Hi "" + name + ""!"" )
+                }[]
+            ";
+
+            var diagnostics = @"
+                Unexpected token <EqualsToken>, expected <CloseParenthesisToken>.
+                Unexpected token <EqualsToken>, expected <OpenBraceToken>.
+                Unexpected token <EqualsToken>, expected <IdentifierToken>.
+                Unexpected token <CloseParenthesisToken>, expected <IdentifierToken>.
+                Unexpected token <EndOfFileToken>, expected <CloseBraceToken>.
+            ";
+
+            AssertDiagnostics(text, diagnostics);
+        }
+
+        [Fact]
         public void EvaluatorIfStatementReportsCannotConvert()
         {
             var text = @"

--- a/NovaLib/CodeAnalysis/Syntax/Parser.cs
+++ b/NovaLib/CodeAnalysis/Syntax/Parser.cs
@@ -110,17 +110,23 @@ namespace Nova.CodeAnalysis.Syntax
         private SeparatedSyntaxList<ParameterSyntax> ParseParameterList()
         {
             var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+            bool parseNextToken = true;
 
-            while (Current.Kind != SyntaxKind.CloseParenthesisToken &&
+            while (parseNextToken &&
+                   Current.Kind != SyntaxKind.CloseParenthesisToken &&
                    Current.Kind != SyntaxKind.EndOfFileToken)
             {
                 ParameterSyntax parameter = ParseParameter();
                 nodesAndSeparators.Add(parameter);
 
-                if (Current.Kind != SyntaxKind.CloseParenthesisToken)
+                if (Current.Kind == SyntaxKind.CommaToken)
                 {
                     SyntaxToken comma = MatchToken(SyntaxKind.CommaToken);
                     nodesAndSeparators.Add(comma);
+                }
+                else
+                {
+                    parseNextToken = false;
                 }
             }
 
@@ -383,17 +389,23 @@ namespace Nova.CodeAnalysis.Syntax
         private SeparatedSyntaxList<ExpressionSyntax> ParseArguments()
         {
             var nodesAndSeparators = ImmutableArray.CreateBuilder<SyntaxNode>();
+            bool parseNextToken = true;
 
-            while (Current.Kind != SyntaxKind.CloseParenthesisToken &&
+            while (parseNextToken &&
+                   Current.Kind != SyntaxKind.CloseParenthesisToken &&
                    Current.Kind != SyntaxKind.EndOfFileToken)
             {
                 ExpressionSyntax expression = ParseExpression();
                 nodesAndSeparators.Add(expression);
 
-                if (Current.Kind != SyntaxKind.CloseParenthesisToken)
+                if (Current.Kind == SyntaxKind.CommaToken)
                 {
                     SyntaxToken comma = MatchToken(SyntaxKind.CommaToken);
                     nodesAndSeparators.Add(comma);
+                }
+                else
+                {
+                    parseNextToken = false;
                 }
             }
 


### PR DESCRIPTION
It can cause infinite loops if they are not valid:
```
print("Hello"=)
```
or:
```
function hi(name: string =) 
{
    print("Hello " + name)
}
```
The next code makes sure to take the last comma token in the parameters.